### PR TITLE
Adding an easily accessible cheat sheet UI

### DIFF
--- a/editor/src/components/ui/CompileButton.vue
+++ b/editor/src/components/ui/CompileButton.vue
@@ -22,32 +22,32 @@
 </template>
 
 <script lang="ts" setup>
-import { ComputedRef, inject, onMounted, onUnmounted } from "vue";
-import { Playground } from "../../store/code";
+import { ComputedRef, inject, onMounted, onUnmounted } from 'vue';
+import { Playground } from '../../store/code';
 
 const emit = defineEmits<{
-  (e: "triggeredCompile"): void;
+  (e: 'triggeredCompile'): void;
 }>();
 
-const store = inject("store") as ComputedRef<Playground>;
+const store = inject('store') as ComputedRef<Playground>;
 
 const compile = () => {
   store.value.compile();
-  emit("triggeredCompile");
+  emit('triggeredCompile');
 };
 
 const handleCompileKeybind = (e: KeyboardEvent) => {
-  if (e.altKey && e.code === "Enter") {
+  if (e.altKey && e.code === 'Enter') {
     e.preventDefault();
     compile();
   }
 };
 
 onMounted(() => {
-  window.addEventListener("keydown", handleCompileKeybind);
+  window.addEventListener('keydown', handleCompileKeybind);
 });
 
 onUnmounted(() => {
-  window.removeEventListener("keydown", handleCompileKeybind);
+  window.removeEventListener('keydown', handleCompileKeybind);
 });
 </script>

--- a/editor/src/components/ui/SyntaxGuideModel.vue
+++ b/editor/src/components/ui/SyntaxGuideModel.vue
@@ -1,8 +1,9 @@
 <template>
-  <div
-    class="font-fira fixed inset-0 bg-black  flex justify-center z-50 h-0"
-  >
-    <div class="h-100 relative bg-black p-6 rounded-lg shadow-xl max-w-md w-full" v-draggable>
+  <div class="font-fira fixed inset-0 bg-black flex justify-center z-50 h-0">
+    <div
+      class="h-100 relative bg-black p-6 rounded-lg shadow-xl max-w-md w-full"
+      v-draggable
+    >
       <button
         @click="$emit('close')"
         class="absolute top-0 right-0 my-4 mx-2 px-2 py-1 bg-black text-white rounded"
@@ -44,15 +45,15 @@
 
 <script lang="ts" setup>
 const syntaxRules = [
-  { name: "Start symbol", syntax: "S" },
-  { name: "Follow (->)", syntax: "->" },
-  { name: "ε or λ", syntax: "ε or λ or #" },
-  { name: "Or (|)", syntax: "|" },
-  { name: "End each rule", syntax: "." },
-  { name: "Comments", syntax: "// comment" },
-  { name: "Non-terminals", syntax: "start with uppercase character" },
-  { name: "Terminals", syntax: "start with any other character" },
+  { name: 'Start symbol', syntax: 'S' },
+  { name: 'Follow (->)', syntax: '->' },
+  { name: 'ε or λ', syntax: 'ε or λ or #' },
+  { name: 'Or (|)', syntax: '|' },
+  { name: 'End each rule', syntax: '.' },
+  { name: 'Comments', syntax: '// comment' },
+  { name: 'Non-terminals', syntax: 'start with uppercase character' },
+  { name: 'Terminals', syntax: 'start with any other character' },
 ];
 
-defineEmits(["close"]);
+defineEmits(['close']);
 </script>

--- a/editor/src/components/ui/SyntaxGuideModel.vue
+++ b/editor/src/components/ui/SyntaxGuideModel.vue
@@ -1,0 +1,58 @@
+<template>
+  <div
+    class="font-fira fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+  >
+    <div class="relative bg-black p-6 rounded-lg shadow-xl max-w-md w-full">
+      <button
+        @click="$emit('close')"
+        class="absolute top-0 right-0 my-4 mx-2 px-2 py-1 bg-black text-white rounded"
+      >
+        <svg
+          class="svg-icon"
+          style="
+            width: 2em;
+            height: 2em;
+            vertical-align: middle;
+            fill: currentColor;
+            overflow: hidden;
+          "
+          viewBox="0 0 1024 1024"
+          version="1.1"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M512 806.764618C349.188606 806.764618 217.235382 674.811394 217.235382 512s131.953223-294.764618 294.764618-294.764618 294.764618 131.953223 294.764618 294.764618-131.953223 294.764618-294.764618 294.764618z m0-39.301949c141.087856 0 255.462669-114.374813 255.462669-255.462669S653.087856 256.537331 512 256.537331 256.537331 370.912144 256.537331 512s114.374813 255.462669 255.462669 255.462669zM549.152624 512l99.329535 99.252774-37.152624 37.152623L512 549.152624 412.747226 648.405397l-37.152623-37.152623L474.847376 512 374.443178 411.595802l37.152624-37.152624L512 474.847376l100.404198-100.404198 37.152624 37.152624L549.152624 512z m0 0"
+          />
+        </svg>
+      </button>
+      <h2 class="font-merri text-cyan-500 text-2xl font-bold mb-4">
+        Syntax Cheat-sheet
+      </h2>
+      <div class="grid gap-2">
+        <div
+          v-for="(rule, index) in syntaxRules"
+          :key="index"
+          class="grid grid-cols-2 gap-2"
+        >
+          <span class="font-medium text-white">{{ rule.name }}</span>
+          <span class="text-cyan-500">{{ rule.syntax }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+const syntaxRules = [
+  { name: "Start symbol", syntax: "S" },
+  { name: "Follow (->)", syntax: "->" },
+  { name: "ε or λ", syntax: "ε or λ or #" },
+  { name: "Or (|)", syntax: "|" },
+  { name: "End each rule", syntax: "." },
+  { name: "Comments", syntax: "// comment" },
+  { name: "Non-terminals", syntax: "start with uppercase character" },
+  { name: "Terminals", syntax: "start with any other character" },
+];
+
+defineEmits(["close"]);
+</script>

--- a/editor/src/components/ui/SyntaxGuideModel.vue
+++ b/editor/src/components/ui/SyntaxGuideModel.vue
@@ -1,8 +1,8 @@
 <template>
   <div
-    class="font-fira fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+    class="font-fira fixed inset-0 bg-black  flex justify-center z-50 h-0"
   >
-    <div class="relative bg-black p-6 rounded-lg shadow-xl max-w-md w-full">
+    <div class="h-100 relative bg-black p-6 rounded-lg shadow-xl max-w-md w-full" v-draggable>
       <button
         @click="$emit('close')"
         class="absolute top-0 right-0 my-4 mx-2 px-2 py-1 bg-black text-white rounded"

--- a/editor/src/components/ui/SyntaxSheet.vue
+++ b/editor/src/components/ui/SyntaxSheet.vue
@@ -1,7 +1,7 @@
 <template>
   <button
-    title="Compile the program [Alt + Enter]"
-    @click="compile"
+    title="Show Syntax Guide [Alt + S]"
+    @click="showSyntaxGuide"
     class="w-16 h-16 rounded-full absolute top-12 -right-16 transform -translate-x-1/2 z-20 inline-flex justify-center items-center border-4 border-solid border-gray-900 focus:outline-none cursor-pointer text-gray-900 bg-cyan-300 transition hover:(bg-cyan-400 scale-110 -translate-x-[50%] shadow-lg)"
   >
     <svg
@@ -11,43 +11,47 @@
       viewBox="0 0 24 24"
       stroke-width="1.5"
       stroke="currentColor"
-      fill="currentColor"
+      fill="none"
       stroke-linecap="round"
       stroke-linejoin="round"
     >
       <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-      <path d="M7 4v16l13 -8z" />
+      <path d="M3 19a9 9 0 0 1 9 0a9 9 0 0 1 9 0" />
+      <path d="M3 6a9 9 0 0 1 9 0a9 9 0 0 1 9 0" />
+      <path d="M3 6l0 13" />
+      <path d="M12 6l0 13" />
+      <path d="M21 6l0 13" />
     </svg>
   </button>
 </template>
 
 <script lang="ts" setup>
 import { ComputedRef, inject, onMounted, onUnmounted } from "vue";
-import { Playground } from "../../store/code";
+import { SyntaxGuide } from "../../store/syntaxGuide";
 
 const emit = defineEmits<{
-  (e: "triggeredCompile"): void;
+  (e: "showSyntaxGuide"): void;
 }>();
 
-const store = inject("store") as ComputedRef<Playground>;
+const store = inject("syntaxStore") as ComputedRef<SyntaxGuide>;
 
-const compile = () => {
-  store.value.compile();
-  emit("triggeredCompile");
+const showSyntaxGuide = () => {
+  store.value.toggleSyntaxGuide();
+  emit("showSyntaxGuide");
 };
 
-const handleCompileKeybind = (e: KeyboardEvent) => {
-  if (e.altKey && e.code === "Enter") {
+const handleSyntaxGuideKeybind = (e: KeyboardEvent) => {
+  if (e.altKey && e.code === "KeyS") {
     e.preventDefault();
-    compile();
+    showSyntaxGuide();
   }
 };
 
 onMounted(() => {
-  window.addEventListener("keydown", handleCompileKeybind);
+  window.addEventListener("keydown", handleSyntaxGuideKeybind);
 });
 
 onUnmounted(() => {
-  window.removeEventListener("keydown", handleCompileKeybind);
+  window.removeEventListener("keydown", handleSyntaxGuideKeybind);
 });
 </script>

--- a/editor/src/components/ui/SyntaxSheet.vue
+++ b/editor/src/components/ui/SyntaxSheet.vue
@@ -23,21 +23,25 @@
       <path d="M21 6l0 13" />
     </svg>
   </button>
+  <Teleport to="body">
+    <Transition name="fade">
+      <SyntaxGuideModal v-if="isSyntaxGuideVisible" @close="closeSyntaxGuide" />
+    </Transition>
+  </Teleport>
 </template>
 
-<script lang="ts" setup>
-import { ComputedRef, inject, onMounted, onUnmounted } from "vue";
-import { SyntaxGuide } from "../../store/syntaxGuide";
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from "vue";
+import SyntaxGuideModal from "./SyntaxGuideModel.vue";
 
-const emit = defineEmits<{
-  (e: "showSyntaxGuide"): void;
-}>();
-
-const store = inject("syntaxStore") as ComputedRef<SyntaxGuide>;
+const isSyntaxGuideVisible = ref(false);
 
 const showSyntaxGuide = () => {
-  store.value.toggleSyntaxGuide();
-  emit("showSyntaxGuide");
+  isSyntaxGuideVisible.value = true;
+};
+
+const closeSyntaxGuide = () => {
+  isSyntaxGuideVisible.value = false;
 };
 
 const handleSyntaxGuideKeybind = (e: KeyboardEvent) => {
@@ -55,3 +59,15 @@ onUnmounted(() => {
   window.removeEventListener("keydown", handleSyntaxGuideKeybind);
 });
 </script>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/editor/src/components/ui/SyntaxSheet.vue
+++ b/editor/src/components/ui/SyntaxSheet.vue
@@ -31,8 +31,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from "vue";
-import SyntaxGuideModal from "./SyntaxGuideModel.vue";
+import { ref, onMounted, onUnmounted } from 'vue';
+import SyntaxGuideModal from './SyntaxGuideModel.vue';
 
 const isSyntaxGuideVisible = ref(false);
 
@@ -45,18 +45,18 @@ const closeSyntaxGuide = () => {
 };
 
 const handleSyntaxGuideKeybind = (e: KeyboardEvent) => {
-  if (e.altKey && e.code === "KeyS") {
+  if (e.altKey && e.code === 'KeyS') {
     e.preventDefault();
     showSyntaxGuide();
   }
 };
 
 onMounted(() => {
-  window.addEventListener("keydown", handleSyntaxGuideKeybind);
+  window.addEventListener('keydown', handleSyntaxGuideKeybind);
 });
 
 onUnmounted(() => {
-  window.removeEventListener("keydown", handleSyntaxGuideKeybind);
+  window.removeEventListener('keydown', handleSyntaxGuideKeybind);
 });
 </script>
 

--- a/editor/src/directives/draggable.ts
+++ b/editor/src/directives/draggable.ts
@@ -32,7 +32,7 @@ const draggable = {
     el.ondragstart = function () {
       return false;
     };
-  }
+  },
 };
 
 export default draggable;

--- a/editor/src/directives/draggable.ts
+++ b/editor/src/directives/draggable.ts
@@ -1,0 +1,38 @@
+// directives/draggable.ts
+import { DirectiveBinding } from 'vue';
+
+const draggable = {
+  mounted(el: HTMLElement) {
+    el.style.position = 'absolute';
+    el.style.cursor = 'move';
+
+    el.onmousedown = function (event) {
+      event.preventDefault();
+
+      const shiftX = event.clientX - el.getBoundingClientRect().left;
+      const shiftY = event.clientY - el.getBoundingClientRect().top;
+
+      const moveAt = (pageX: number, pageY: number) => {
+        el.style.left = pageX - shiftX + 'px';
+        el.style.top = pageY - shiftY + 'px';
+      };
+
+      const onMouseMove = (event: MouseEvent) => {
+        moveAt(event.pageX, event.pageY);
+      };
+
+      document.addEventListener('mousemove', onMouseMove);
+
+      el.onmouseup = function () {
+        document.removeEventListener('mousemove', onMouseMove);
+        el.onmouseup = null;
+      };
+    };
+
+    el.ondragstart = function () {
+      return false;
+    };
+  }
+};
+
+export default draggable;

--- a/editor/src/main.ts
+++ b/editor/src/main.ts
@@ -7,7 +7,7 @@ import GrowSlideTransition from './components/transitions/GrowSlideTransition.vu
 
 import 'splitpanes/dist/splitpanes.css';
 import 'virtual:windi.css';
-
+import draggable from './directives/draggable';
 const app = createApp(App);
 
 app.directive('life', {
@@ -19,5 +19,6 @@ app.directive('life', {
 app.component('FadeTransition', FadeTransition);
 app.component('GrowSlideTransition', GrowSlideTransition);
 
+app.directive('draggable', draggable);
 app.use(router);
 app.mount('#app');

--- a/editor/src/router.ts
+++ b/editor/src/router.ts
@@ -7,17 +7,6 @@ const sampleProgram = `
 S -> 0 1 S | 1 0 S | A.
 A -> 0 1 A | 1 0 A | #.
 
-// Type your grammar here...
-
-// Syntax cheat-sheet:
-//    * Start symbol                 S
-//    * Follow (->):                 ->
-//    * ε or λ:                      ε or λ or #
-//    * Or (|):                      |
-//    * End each rule:               .
-//    * Comments:                    // comment
-//    * Non-terminals:               start with uppercase character
-//    * Terminals:                   start with any other character
 `;
 
 const router = createRouter({

--- a/editor/src/router.ts
+++ b/editor/src/router.ts
@@ -24,12 +24,22 @@ const router = createRouter({
       component: Playground,
       beforeEnter(to, _, next) {
         try {
-          playgrounds.push(newPlayground('Program 1', (to.params.type as string).toUpperCase() as PlaygroundType, sampleProgram));
-          return next({ name: 'Playground', params: { id: 0 }, query: to.query });
-        } catch(err) {
+          playgrounds.push(
+            newPlayground(
+              'Program 1',
+              (to.params.type as string).toUpperCase() as PlaygroundType,
+              sampleProgram
+            )
+          );
+          return next({
+            name: 'Playground',
+            params: { id: 0 },
+            query: to.query,
+          });
+        } catch (err) {
           return next({ name: '404' });
         }
-      }
+      },
     },
     {
       name: 'Playground',
@@ -37,7 +47,11 @@ const router = createRouter({
       component: Playground,
       beforeEnter(to, _, next) {
         if (!to.params.id || Number(to.params.id) >= playgrounds.length) {
-          return next({ name: 'NewPlayground', params: { type: 'RG' }, query: to.query });
+          return next({
+            name: 'NewPlayground',
+            params: { type: 'RG' },
+            query: to.query,
+          });
         } else {
           return next();
         }
@@ -56,7 +70,9 @@ router.afterEach((to) => {
 
   // Update page title to new tab's name
   if (to.name === 'Playground') {
-    document.title = `${playgrounds[Number(to.params.id)].name} | Vyaakaran Playground`;
+    document.title = `${
+      playgrounds[Number(to.params.id)].name
+    } | Vyaakaran Playground`;
   }
 });
 

--- a/editor/src/routes/Playground.vue
+++ b/editor/src/routes/Playground.vue
@@ -1,22 +1,29 @@
 <template>
   <div class="relative flex flex-col" v-if="getView().type !== 'default'">
-    <EditorTabs @new-playground="() => showNewPlaygroundModal = true" />
+    <EditorTabs @new-playground="() => (showNewPlaygroundModal = true)" />
     <Splitpanes class="flex relative w-screen view" :dbl-click-splitter="false">
       <component :is="getView().view" />
     </Splitpanes>
   </div>
   <div class="relative flex flex-col" v-else>
-    <EditorTabs @new-playground="() => showNewPlaygroundModal = true" />
+    <EditorTabs @new-playground="() => (showNewPlaygroundModal = true)" />
 
     <Splitpanes class="flex relative w-screen view" :dbl-click-splitter="false">
       <Pane class="relative overflow-visible" min-size="25" size="45">
-        <Splitpanes class="h-full editor-console-split" horizontal :dbl-click-splitter="false">
+        <Splitpanes
+          class="h-full editor-console-split"
+          horizontal
+          :dbl-click-splitter="false"
+        >
           <Pane>
             <Editor />
           </Pane>
           <Console />
         </Splitpanes>
-        <CompileButton />
+        <div class="flex flex-col items-end space-y-20">
+          <CompileButton />
+          <SyntaxSheet />
+        </div>
       </Pane>
 
       <Pane min-size="45">
@@ -24,46 +31,55 @@
       </Pane>
     </Splitpanes>
   </div>
-  <NewPlaygroundModal :show="showNewPlaygroundModal" @close="showNewPlaygroundModal = false" />
-  <footer class="h-6 text-xxs flex items-center px-5 bg-gray-900 text-cool-gray-500 border-t border-solid border-gray-800 font-semibold justify-end space-x-2">
+  <NewPlaygroundModal
+    :show="showNewPlaygroundModal"
+    @close="showNewPlaygroundModal = false"
+  />
+  <footer
+    class="h-6 text-xxs flex items-center px-5 bg-gray-900 text-cool-gray-500 border-t border-solid border-gray-800 font-semibold justify-end space-x-2"
+  >
     <span>
       A side project designed & developed by
-      {{ ' ' }}
-      <a class="text-cyan-300" href="https://akashhamirwasia.com">Akash Hamirwasia</a>
+      {{ " " }}
+      <a class="text-cyan-300" href="https://akashhamirwasia.com"
+        >Akash Hamirwasia</a
+      >
     </span>
-    <span>
-      Vyaakaran v{{ pkg.version }}
-    </span>
+    <span> Vyaakaran v{{ pkg.version }} </span>
   </footer>
 </template>
 
 <script lang="ts" setup>
-import { computed, provide, ref } from 'vue';
-import { Splitpanes, Pane } from 'splitpanes';
-import { useRoute } from 'vue-router';
+import { computed, provide, ref } from "vue";
+import { Splitpanes, Pane } from "splitpanes";
+import { useRoute } from "vue-router";
 
-import { getActivePlayground, PlaygroundType } from '../store/code';
-import pkg from '../../package.json';
+import { getActivePlayground, PlaygroundType } from "../store/code";
+import pkg from "../../package.json";
 
-import NewPlaygroundModal from '../components/NewPlaygroundModal.vue';
-import CompileButton from '../components/ui/CompileButton.vue';
-import Editor from '../components/Editor.vue';
-import Console from '../components/Console.vue';
-import EditorTabs from '../components/EditorTabs/EditorTabs.vue';
-import RegularGrammarPlayground from '../components/playgrounds/RegularGrammar.vue';
-import ContextFreeGrammarPlayground from '../components/playgrounds/ContextFreeGrammar.vue';
-import TuringMachinePlayground from '../components/playgrounds/TuringMachine.vue';
+import NewPlaygroundModal from "../components/NewPlaygroundModal.vue";
+import CompileButton from "../components/ui/CompileButton.vue";
+import SyntaxSheet from "../components/ui/SyntaxSheet.vue";
+import Editor from "../components/Editor.vue";
+import Console from "../components/Console.vue";
+import EditorTabs from "../components/EditorTabs/EditorTabs.vue";
+import RegularGrammarPlayground from "../components/playgrounds/RegularGrammar.vue";
+import ContextFreeGrammarPlayground from "../components/playgrounds/ContextFreeGrammar.vue";
+import TuringMachinePlayground from "../components/playgrounds/TuringMachine.vue";
 
-import RegularGrammarAutomataExplainer from '../components/explainers/RegularGrammarAutomata.vue';
-import useKeyShortcut from '../utils/useKeyShortcut';
+import RegularGrammarAutomataExplainer from "../components/explainers/RegularGrammarAutomata.vue";
+import useKeyShortcut from "../utils/useKeyShortcut";
 
-const views: Record<PlaygroundType, Record<string, { params?: string[], view: any }>> = {
+const views: Record<
+  PlaygroundType,
+  Record<string, { params?: string[]; view: any }>
+> = {
   RG: {
     nfa: {
       params: [],
       view: RegularGrammarAutomataExplainer,
     },
-    'ε-nfa': {
+    "ε-nfa": {
       params: [],
       view: RegularGrammarAutomataExplainer,
     },
@@ -86,24 +102,30 @@ const views: Record<PlaygroundType, Record<string, { params?: string[], view: an
 const playground = computed(getActivePlayground);
 const showNewPlaygroundModal = ref(false);
 const route = useRoute();
-provide('store', playground);
+provide("store", playground);
 
 const getView = () => {
-  let explain = (
-    (Array.isArray(route.query['explain']) ? route.query['explain'][0] : route.query['explain'])
-    ??
-    'default'
-  );
+  let explain =
+    (Array.isArray(route.query["explain"])
+      ? route.query["explain"][0]
+      : route.query["explain"]) ?? "default";
 
-  if (explain === 'default' || playground.value.errors.length || !playground.value.compiled) {
-    return { type: 'default', view: views[playground.value.type].default.view };
+  if (
+    explain === "default" ||
+    playground.value.errors.length ||
+    !playground.value.compiled
+  ) {
+    return { type: "default", view: views[playground.value.type].default.view };
   }
 
   const params = views[playground.value.type][explain].params ?? [];
 
-  for(const param of params) {
+  for (const param of params) {
     if (route.query[param] === undefined) {
-      return { type: 'default', view: views[playground.value.type].default.view };
+      return {
+        type: "default",
+        view: views[playground.value.type].default.view,
+      };
     }
   }
 
@@ -111,9 +133,12 @@ const getView = () => {
 };
 
 // New playground hotkey
-useKeyShortcut((e) => e.shiftKey && e.code === 'KeyN', () => {
-  showNewPlaygroundModal.value = true;
-});
+useKeyShortcut(
+  (e) => e.shiftKey && e.code === "KeyN",
+  () => {
+    showNewPlaygroundModal.value = true;
+  }
+);
 </script>
 
 <style scoped>

--- a/editor/src/routes/Playground.vue
+++ b/editor/src/routes/Playground.vue
@@ -40,7 +40,7 @@
   >
     <span>
       A side project designed & developed by
-      {{ " " }}
+      {{ ' ' }}
       <a class="text-cyan-300" href="https://akashhamirwasia.com"
         >Akash Hamirwasia</a
       >
@@ -50,25 +50,25 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, provide, ref } from "vue";
-import { Splitpanes, Pane } from "splitpanes";
-import { useRoute } from "vue-router";
+import { computed, provide, ref } from 'vue';
+import { Splitpanes, Pane } from 'splitpanes';
+import { useRoute } from 'vue-router';
 
-import { getActivePlayground, PlaygroundType } from "../store/code";
-import pkg from "../../package.json";
+import { getActivePlayground, PlaygroundType } from '../store/code';
+import pkg from '../../package.json';
 
-import NewPlaygroundModal from "../components/NewPlaygroundModal.vue";
-import CompileButton from "../components/ui/CompileButton.vue";
-import SyntaxSheet from "../components/ui/SyntaxSheet.vue";
-import Editor from "../components/Editor.vue";
-import Console from "../components/Console.vue";
-import EditorTabs from "../components/EditorTabs/EditorTabs.vue";
-import RegularGrammarPlayground from "../components/playgrounds/RegularGrammar.vue";
-import ContextFreeGrammarPlayground from "../components/playgrounds/ContextFreeGrammar.vue";
-import TuringMachinePlayground from "../components/playgrounds/TuringMachine.vue";
+import NewPlaygroundModal from '../components/NewPlaygroundModal.vue';
+import CompileButton from '../components/ui/CompileButton.vue';
+import SyntaxSheet from '../components/ui/SyntaxSheet.vue';
+import Editor from '../components/Editor.vue';
+import Console from '../components/Console.vue';
+import EditorTabs from '../components/EditorTabs/EditorTabs.vue';
+import RegularGrammarPlayground from '../components/playgrounds/RegularGrammar.vue';
+import ContextFreeGrammarPlayground from '../components/playgrounds/ContextFreeGrammar.vue';
+import TuringMachinePlayground from '../components/playgrounds/TuringMachine.vue';
 
-import RegularGrammarAutomataExplainer from "../components/explainers/RegularGrammarAutomata.vue";
-import useKeyShortcut from "../utils/useKeyShortcut";
+import RegularGrammarAutomataExplainer from '../components/explainers/RegularGrammarAutomata.vue';
+import useKeyShortcut from '../utils/useKeyShortcut';
 
 const views: Record<
   PlaygroundType,
@@ -79,7 +79,7 @@ const views: Record<
       params: [],
       view: RegularGrammarAutomataExplainer,
     },
-    "ε-nfa": {
+    'ε-nfa': {
       params: [],
       view: RegularGrammarAutomataExplainer,
     },
@@ -102,20 +102,20 @@ const views: Record<
 const playground = computed(getActivePlayground);
 const showNewPlaygroundModal = ref(false);
 const route = useRoute();
-provide("store", playground);
+provide('store', playground);
 
 const getView = () => {
   let explain =
-    (Array.isArray(route.query["explain"])
-      ? route.query["explain"][0]
-      : route.query["explain"]) ?? "default";
+    (Array.isArray(route.query['explain'])
+      ? route.query['explain'][0]
+      : route.query['explain']) ?? 'default';
 
   if (
-    explain === "default" ||
+    explain === 'default' ||
     playground.value.errors.length ||
     !playground.value.compiled
   ) {
-    return { type: "default", view: views[playground.value.type].default.view };
+    return { type: 'default', view: views[playground.value.type].default.view };
   }
 
   const params = views[playground.value.type][explain].params ?? [];
@@ -123,7 +123,7 @@ const getView = () => {
   for (const param of params) {
     if (route.query[param] === undefined) {
       return {
-        type: "default",
+        type: 'default',
         view: views[playground.value.type].default.view,
       };
     }
@@ -134,7 +134,7 @@ const getView = () => {
 
 // New playground hotkey
 useKeyShortcut(
-  (e) => e.shiftKey && e.code === "KeyN",
+  (e) => e.shiftKey && e.code === 'KeyN',
   () => {
     showNewPlaygroundModal.value = true;
   }


### PR DESCRIPTION


### Description:
This PR addresses the issue [#4](https://github.com/blenderskool/vyaakaran/issues/4) raised. The following enhancements are made to make the cheat sheet more accessible:

### Changes made:

**Button in split pane section**

- A button has been added along the split pane which displays a component with the same data given in the example 
- This component is made draggable, and background active for seamlessly accessing the syntax while adding the grammar 
- The syntax within the example has been removed to show just the rules of grammar

---